### PR TITLE
Fix SPI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fordo-one%2Fpackage-histogram%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/ordo-one/package-histogram)
-[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fordo-one%2Fpackage-histogram%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/ordo-one/package-histogram)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FHdrHistogram%2Fhdrhistogram-swift%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/HdrHistogram/hdrhistogram-swift)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FHdrHistogram%2Fhdrhistogram-swift%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/HdrHistogram/hdrhistogram-swift)
 [![codecov](https://codecov.io/gh/ordo-one/package-histogram/branch/main/graph/badge.svg?token=o6efZbwgoD)](https://codecov.io/gh/ordo-one/package-histogram)
 [![Swift address sanitizer](https://github.com/ordo-one/package-histogram/actions/workflows/swift-sanitizer-address.yml/badge.svg)](https://github.com/ordo-one/package-histogram/actions/workflows/swift-sanitizer-address.yml)
 [![Swift thread sanitizer](https://github.com/ordo-one/package-histogram/actions/workflows/swift-sanitizer-thread.yml/badge.svg)](https://github.com/ordo-one/package-histogram/actions/workflows/swift-sanitizer-thread.yml)


### PR DESCRIPTION
I noticed that the SPI badges were in "pending" state after the repository rename. This should correct that.

(The same change probably needs to happen with some of the other badges as well but I only touched the ones I was sure about!)