### PR TITLE
docs(patch): updating README to fix link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Histogram is a port of Gil Tene's [High Dynamic Range (HDR) Histogram](http://hd
 
 Histogram supports the recording and analyzing of sampled data value counts across a configurable integer value range with configurable value precision within the range. Value precision is expressed as the number of significant digits in the value recording, and provides control over value quantization behavior across the value range and the subsequent value resolution at any given level.
 
-For example, a Histogram could be configured to track the counts of observed integer values between 0 and 3,600,000,000 while maintaining a value precision of 3 significant digits across that range. Value quantization within the range will thus be no larger than 1/1,000th (or 0.1%) of any value. 
+For example, a Histogram could be configured to track the counts of observed integer values between 0 and 3,600,000,000 while maintaining a value precision of 3 significant digits across that range. Value quantization within the range will thus be no larger than 1/1,000th (or 0.1%) of any value.
 
 This example Histogram could be used to track and analyze the counts of observed response times ranging between 1 microsecond and 1 hour in magnitude, while maintaining a value resolution of 1 microsecond up to 1 millisecond, a resolution of 1 millisecond (or better) up to one second, and a resolution of 1 second (or better) up to 1,000 seconds. At it's maximum tracked value (1 hour), it would still maintain a resolution of 3.6 seconds (or better).
 
@@ -33,8 +33,10 @@ Users are encouraged to read the documentation from the original [Java implement
 as most of the concepts translate directly to the Swift port. Additional Thanks to the maintainers of the Rust port for a nice introduction to the package that we've largely borrowed.
 
 # Adding dependencies
+
 To add to your project:
-```
+
+```swift
 dependencies: [
     .package(url: "https://github.com/HdrHistogram/hdrhistogram-swift", .upToNextMajor(from: "0.1.0"))
 ]
@@ -42,20 +44,21 @@ dependencies: [
 
 and then add the dependency to your target, e.g.:
 
-```
+```swift
 .executableTarget(
   name: "MyExecutableTarget",
   dependencies: [
   .product(name: "Histogram", package: "hdrhistogram-swift")
 ]),
 ```
+
 ## Usage
 
-The Histogram API follows that of the original HdrHistogram Java implementation, with some modifications to make its use more idiomatic in Swift. 
+The Histogram API follows that of the original HdrHistogram Java implementation, with some modifications to make its use more idiomatic in Swift.
 
-[Documentation for the classes and API](https://swiftpackageindex.com/ordo-one/package-histogram/main/documentation/Histogram) are hosted by the [SwiftPackageIndex](http://www.swiftpackageindex.com)
+[Documentation for the classes and API](https://swiftpackageindex.com/HdrHistogram/hdrhistogram-swift/documentation/histogram) are hosted by the [SwiftPackageIndex](http://www.swiftpackageindex.com)
 
-# Simple example 
+# Simple example
 
 (see implementation in Sources/HistogramExample)
 
@@ -100,4 +103,3 @@ print("stddev: \(histogram.stdDeviation)")
 
 print("\(histogram)")
 ```
-


### PR DESCRIPTION
docs: update to the README to fix the link to the documentation hosted in Swift Package Index (not updated after the repo moved into the HDRHistogram org)